### PR TITLE
add systemd-timesyncd to Ubuntu and Debian

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ resource "metal_reserved_ip_block" "ingress_vip" {
 data "template_file" "user_data" {
   template = file("templates/user_data.sh")
   vars = {
-    operating_system = var.operating_system
   }
 }
 

--- a/templates/user_data.sh
+++ b/templates/user_data.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-OS='${operating_system}'
-
-if [ "$${OS:0:6}" = "centos" ] || [ "$${OS:0:4}" = "rhel" ]; then
+distro=$(lsb_release -i -s | tr A-Z a-z)
+case $distro in
+  ubuntu|debian)
+    export DEBIAN_FRONTEND=noninteractive
+    apt update -q
+    apt install -qy systemd-timesyncd
+    apt autoremove -qy
+    ;;
+  centos|redhatenterprise)
     dnf install jq -y
-fi
+    ;;
+esac
 
 GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
 sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces


### PR DESCRIPTION
There are some reports that the local ntpd configuration is causing delays during install.

This changes Debian and Ubuntu installs to use systemd-timesyncd.

when I apply'd this change: (3x c3.small workers, no ha, facility da11)

```
null_resource.prep_anthos_cluster: Creation complete after 48s [id=1439661894416930949]
null_resource.kube_vip_install_first_cp: Creation complete after 15m58s [id=5014713027315226937]
null_resource.deploy_anthos_cluster: Creation complete after 17m11s [id=4302241430436461654]
```