### PR TITLE
Allow use as a Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ EOF
 |     cluster_name       | string  |  equinix-metal-gke-cluster  | The name of the GKE cluster                             |
 |    create_project      | string  |           true              | Create a new project for this deployment?               |
 |     project_name       | string  |       baremetal-anthos      | The name of the project if 'create_project' is 'true'.  |
+|     gcp_keys_path      | string  |          util/keys          | The path to a directory with GCP service account keys   |
 |        bgp_asn         | string  |            65000            | BGP ASN to peer with Equinix Metal                      |
 |      ccm_version       | string  |           v2.0.0            | The version of the Equinix Metal CCM                    |
 |    kube_vip_version    | string  |            0.2.3            | The version of Kube-VIP to install                      |

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "metal_reserved_ip_block" "ingress_vip" {
 }
 
 data "template_file" "user_data" {
-  template = file("templates/user_data.sh")
+  template = file("${path.module}/templates/user_data.sh")
   vars = {
     operating_system = var.operating_system
   }
@@ -124,7 +124,7 @@ resource "null_resource" "write_ssh_private_key" {
 }
 
 data "template_file" "deploy_anthos_cluster" {
-  template = file("templates/pre_reqs.sh")
+  template = file("${path.module}/templates/pre_reqs.sh")
   vars = {
     cluster_name     = local.cluster_name
     operating_system = var.operating_system
@@ -152,7 +152,7 @@ resource "null_resource" "prep_anthos_cluster" {
   }
 
   provisioner "file" {
-    source      = "util/keys/"
+    source      = "${var.gcp_keys_path}/"
     destination = "/root/baremetal/keys"
   }
 
@@ -167,7 +167,7 @@ resource "null_resource" "prep_anthos_cluster" {
 }
 
 data "template_file" "create_cluster" {
-  template = file("templates/create_cluster.sh")
+  template = file("${path.module}/templates/create_cluster.sh")
   vars = {
     cluster_name = local.cluster_name
   }
@@ -207,7 +207,7 @@ resource "null_resource" "download_kube_config" {
 
 data "template_file" "template_kube_vip_install" {
   count    = var.ha_control_plane ? 2 : 1
-  template = file("templates/kube_vip_install.sh")
+  template = file("${path.module}/templates/kube_vip_install.sh")
   vars = {
     cluster_name = local.cluster_name
     eip          = cidrhost(metal_reserved_ip_block.cp_vip.cidr_notation, 0)
@@ -244,7 +244,7 @@ resource "null_resource" "kube_vip_install_first_cp" {
 
 data "template_file" "add_remaining_cps" {
   count    = var.ha_control_plane ? 1 : 0
-  template = file("templates/add_remaining_cps.sh")
+  template = file("${path.module}/templates/add_remaining_cps.sh")
   vars = {
     cluster_name = local.cluster_name
     cp_2         = metal_device.control_plane.1.access_private_ipv4
@@ -301,7 +301,7 @@ resource "null_resource" "kube_vip_install_remaining_cp" {
 }
 
 data "template_file" "worker_kubelet_flags" {
-  template = file("templates/worker_kubelet_flags.sh")
+  template = file("${path.module}/templates/worker_kubelet_flags.sh")
 }
 
 resource "null_resource" "add_kubelet_flags_to_workers" {
@@ -334,7 +334,7 @@ resource "null_resource" "add_kubelet_flags_to_workers" {
 }
 
 data "template_file" "ccm_secret" {
-  template = file("templates/ccm_secret.yaml")
+  template = file("${path.module}/templates/ccm_secret.yaml")
   vars = {
     auth_token = var.auth_token
     project_id = local.project_id
@@ -364,7 +364,7 @@ resource "null_resource" "install_ccm" {
 }
 
 data "template_file" "kube_vip_ds" {
-  template = file("templates/kube_vip_ds.yaml")
+  template = file("${path.module}/templates/kube_vip_ds.yaml")
 }
 
 resource "null_resource" "install_kube_vip_daemonset" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "project_name" {
   description = "The name of the project if 'create_project' is 'true'."
 }
 
+variable "gcp_keys_path" {
+  type        = string
+  default     = "util/keys"
+  description = "The path to a directory that contains the required GCP service account keys"
+}
+
 # Advanced Variables below this line
 
 variable "bgp_asn" {


### PR DESCRIPTION
This PR contains updates to allow the use of this repository as a Terraform module, for example:

```
module "cluster-metal" {
  source  = "equinix/anthos-on-baremetal/metal"
  version = "0.X.0"

  organization_id = var.metal_organization_id
  auth_token      = var.metal_auth_token
  project_id      = var.metal_project_id
  cluster_name    = var.metal_cluster_name
  create_project  = var.metal_create_project
  gcp_keys_path   = var.metal_gcp_keys_path
}
```

This is done by:

- Prefixing the `templates` directory path with `path.module` to be absolute rather than relative, and
- Variablising the path to the `util/keys` directory that contains the GCP service account keys

This is a non-breaking change (i.e. does not affect the use of the codebase in "non-module" mode).