### PR TITLE
Use traditional apt-get to avoid terminal issues

### DIFF
--- a/templates/pre_reqs.sh
+++ b/templates/pre_reqs.sh
@@ -11,13 +11,13 @@ IFS=' ' read -r -a WORKER_IPS <<< '${worker_ips}'
 function ubuntu_pre_reqs {
     # Install Docker
     export DEBIAN_FRONTEND=noninteractive
-    sudo apt update -qy
-    sudo apt install apt-transport-https ca-certificates curl software-properties-common gnupg -qy
+    sudo apt-get update -qy
+    sudo apt-get install apt-transport-https ca-certificates curl software-properties-common gnupg -qy
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" -y
-    sudo apt update -qy
+    sudo apt-get update -qy
     DOCKER_VERSION=`sudo apt-cache madison docker-ce | grep '19.03.13' | awk '{print $3}'`
-    sudo apt install docker-ce=$DOCKER_VERSION -qy
+    sudo apt-get install docker-ce=$DOCKER_VERSION -qy
     sudo usermod -aG docker $USER
 
     # Install Google Cloud SDK


### PR DESCRIPTION
Fixes #35 by reverting to `apt-get`, which does not display a progress bar.