### PR TITLE
Use Terraform to enable GCP APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf
+!.terraform.lock.hcl
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,123 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/equinix/metal" {
+  version = "1.0.0"
+  hashes = [
+    "h1:nUIvAmwG1AIo5FCrqiNoB9oWHjRs5K6YTwr2T3iIEkY=",
+    "zh:06bf3f257e490891a9470e6b559d27b4136c2a699d05eb5690cad5fec98d7d4d",
+    "zh:0d1312af7461a3ee6def3f91e82ac0b06c66667423c459791cf52dda75527428",
+    "zh:0d866ece81ff174d5a25890ed18672e15a5ddd88834335289b62541690076ab8",
+    "zh:0fb605b2271883a8a76d330ca479687f8ee001f47594ff289f7aeb9df4d2265a",
+    "zh:2f5f6f582bd11a24cca99fbde1da31999dd8c3d1117f17ee2d5f9eb048e02100",
+    "zh:3d12c99b463f732eb5f4a81f38b6eeba4314892669f4ce3ced8d91cd2b9209a3",
+    "zh:6045a87e5b74c90fbe07352aedab1ec3175c421b36caebeaacc1f7446bede27c",
+    "zh:6528716f0fdd24b4eada6ca5b526f12f19bdf987e998abc2ec5942d59986be6a",
+    "zh:7bc75f9b60928d8b843e4342b069724e224ff051c54e606efaa1b080d25e8f6e",
+    "zh:b530619842716e48342fc79b04b2b261c89bc26019c9bac4993ea532b17b3b89",
+    "zh:c3321a23259cbdb0488a0450a85197db4a467776287e96cf67c5731d9f83c58e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "3.53.0"
+  constraints = "~> 3.53.0"
+  hashes = [
+    "h1:AzrT8ueZHo7GrEWFiXi3eB/NOQoXcVE/w6fLcRJyc34=",
+    "zh:1408365b5f2ae508fce9b446bb9dbaf044aec81fa4c36fff39c2511b179bcc56",
+    "zh:1d53e978065feb6278bc8c88a70c3df7599c3b8bbcd77765bcd842a83bce6686",
+    "zh:5173a92249c8d06d0d2beca0e328df6e956becd789ebae9a064f022151415b8f",
+    "zh:5bd2ee6cd6baf2cb429f82140cbb5e6c90362b0ef4edaf63df30520e01507374",
+    "zh:65670355fddde75bfadc088627e2700dc14054a63aa5434d2759e7fe43b989c6",
+    "zh:97d4382855c50a2077d3ecd241a02324b8ba2cb8b8c76f8f896c40189260f6c1",
+    "zh:9a18ad92e062dcd2ef72ed9021d5827326a2fc13c2c442c54baf6a9298035873",
+    "zh:b4941a0f47f05c965af42821d51748ac326aea2843b123663dd50f7075fa1956",
+    "zh:f40bbb7046dfcd12ddef175acb1cfc4a8ae082f56a24ba413f0719747789915b",
+    "zh:f60769112a2e36beb762dc7f31916f818b5cacfb35d7d8ddeb40ea6bf8690e9e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.0.0"
+  hashes = [
+    "h1:V1tzrSG6t3e7zWvUwRbGbhsWU2Jd/anrJpOl9XM+R/8=",
+    "zh:05fb7eab469324c97e9b73a61d2ece6f91de4e9b493e573bfeda0f2077bc3a4c",
+    "zh:1688aa91885a395c4ae67636d411475d0b831e422e005dcf02eedacaafac3bb4",
+    "zh:24a0b1292e3a474f57c483a7a4512d797e041bc9c2fbaac42fe12e86a7fb5a3c",
+    "zh:2fc951bd0d1b9b23427acc93be09b6909d72871e464088171da60fbee4fdde03",
+    "zh:6db825759425599a326385a68acc6be2d9ba0d7d6ef587191d0cdc6daef9ac63",
+    "zh:85985763d02618993c32c294072cc6ec51f1692b803cb506fcfedca9d40eaec9",
+    "zh:a53186599c57058be1509f904da512342cfdc5d808efdaf02dec15f0f3cb039a",
+    "zh:c2e07b49b6efa676bdc7b00c06333ea1792a983a5720f9e2233db27323d2707c",
+    "zh:cdc8fe1096103cf5374751e2e8408ec4abd2eb67d5a1c5151fe2c7ecfd525bef",
+    "zh:dbdef21df0c012b0d08776f3d4f34eb0f2f229adfde07ff252a119e52c0f65b7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.0.1"
+  hashes = [
+    "h1:0QaSbRBgBi8vI/8IRwec1INdOqBxXbgsSFElx1O4k4g=",
+    "zh:0d4f683868324af056a9eb2b06306feef7c202c88dbbe6a4ad7517146a22fb50",
+    "zh:4824b3c7914b77d41dfe90f6f333c7ac9860afb83e2a344d91fbe46e5dfbec26",
+    "zh:4b82e43712f3cf0d0cbc95b2cbcd409ba8f0dc7848fdfb7c13633c27468ed04a",
+    "zh:78b3a2b860c3ebc973a794000015f5946eb59b82705d701d487475406b2612f1",
+    "zh:88bc65197bd74ff408d147b32f0045372ae3a3f2a2fdd7f734f315d988c0e4a2",
+    "zh:91bd3c9f625f177f3a5d641a64e54d4b4540cb071070ecda060a8261fb6eb2ef",
+    "zh:a6818842b28d800f784e0c93284ff602b0c4022f407e4750da03f50b853a9a2c",
+    "zh:c4a1a2b52abd05687e6cfded4a789dcd7b43e7a746e4d02dd1055370cf9a994d",
+    "zh:cf65041bf12fc3bde709c1d267dbe94142bc05adcabc4feb17da3b12249132ac",
+    "zh:e385e00e7425dda9d30b74ab4ffa4636f4b8eb23918c0b763f0ffab84ece0c5c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}

--- a/gcp-apis.tf
+++ b/gcp-apis.tf
@@ -1,0 +1,20 @@
+locals {
+  enabled_apis = [
+    "anthos.googleapis.com",
+    "anthosgke.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "gkeconnect.googleapis.com",
+    "serviceusage.googleapis.com",
+    "stackdriver.googleapis.com",
+    "monitoring.googleapis.com",
+    "logging.googleapis.com"
+  ]
+}
+
+resource "google_project_service" "enabled-apis" {
+  for_each           = toset(local.enabled_apis)
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/output.tf
+++ b/output.tf
@@ -29,6 +29,6 @@ output "Kubeconfig_location" {
 }
 
 output "Equinix_Metal_Project_ID" {
-  value       = local.project_id
-  description = "The project ID used for this deployment"
+  value       = local.metal_project_id
+  description = "The Metal project ID used for this deployment"
 }

--- a/util/setup_gcp_project.sh
+++ b/util/setup_gcp_project.sh
@@ -57,18 +57,3 @@ gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SUPERA
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SUPERADMIN@$PROJECT.iam.gserviceaccount.com" --role='roles/iam.serviceAccountKeyAdmin'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SUPERADMIN@$PROJECT.iam.gserviceaccount.com" --role='roles/resourcemanager.projectIamAdmin'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SUPERADMIN@$PROJECT.iam.gserviceaccount.com" --role='roles/editor'
-
-
-#enable the required APIs for the project
-gcloud services enable \
-    anthos.googleapis.com \
-    anthosgke.googleapis.com \
-    cloudresourcemanager.googleapis.com \
-    container.googleapis.com \
-    iam.googleapis.com \
-    gkeconnect.googleapis.com \
-    gkehub.googleapis.com \
-    serviceusage.googleapis.com \
-    stackdriver.googleapis.com \
-    monitoring.googleapis.com \
-    logging.googleapis.com --project $PROJECT

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,15 @@
-variable "auth_token" {
+variable "metal_auth_token" {
   type        = string
   description = "Equinix Metal API Key"
 }
 
-variable "project_id" {
+variable "metal_project_id" {
   type        = string
   default     = "null"
   description = "Equinix Metal Project ID"
 }
 
-variable "organization_id" {
+variable "metal_organization_id" {
   type        = string
   default     = "null"
   description = "Equinix Metal Organization ID"
@@ -69,16 +69,22 @@ variable "cluster_name" {
   description = "The GKE cluster name"
 }
 
-variable "create_project" {
+variable "metal_create_project" {
   type        = bool
   default     = true
-  description = "Create a Project if this is 'true'. Else use provided 'project_id'"
+  description = "Create a Metal Project if this is 'true'. Else use provided 'metal_project_id'"
 }
 
-variable "project_name" {
+variable "metal_project_name" {
   type        = string
   default     = "baremetal-anthos"
-  description = "The name of the project if 'create_project' is 'true'."
+  description = "The name of the Metal project if 'create_project' is 'true'."
+}
+
+variable "gcp_project_id" {
+  type        = string
+  default     = ""
+  description = "The GCP project ID to use"
 }
 
 variable "gcp_keys_path" {

--- a/versions.tf
+++ b/versions.tf
@@ -18,6 +18,10 @@ terraform {
     local = {
       source = "hashicorp/local"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = "~>3.53.0"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
This PR moves GCP API enablement from the `gcp_setup.sh` script into Terraform. It also tees up some requirements for a subsequent PR to create and manage the required GCP service accounts, without needing to download long-lived service account keys. Note that this makes `gcp_project_id` a required input variable.