### PR TITLE
fix template/ path that is not module safe

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ data "template_file" "deploy_anthos_cluster" {
 }
 
 data "template_file" "pre_reqs_worker" {
-  template = file("templates/pre_reqs_worker.sh")
+  template = file("${path.module}/templates/pre_reqs_worker.sh")
   vars = {
     operating_system = var.operating_system
   }


### PR DESCRIPTION
https://gist.github.com/displague/e4f98fdb9e2da99a4c5174d6831f627f

```
$ terraform validate

Error: Invalid function argument

  on .terraform/modules/anthos-on-baremetal/main.tf line 149, in data "template_file" "pre_reqs_worker":
 149:   template = file("templates/pre_reqs_worker.sh")

Invalid value for "path" parameter: no file exists at
templates/pre_reqs_worker.sh; this function works only with files that are
distributed as part of the configuration source code, so if this file will be
created by a resource in this configuration you must instead obtain this
result from an attribute of that resource.
```