### PR TITLE
Add provider meta module_name in Equinix Metal TF configs

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,10 +1,10 @@
 output "Control_Plane_Public_IPs" {
-  value       = metal_device.control_plane.*.access_public_ipv4
+  value       = equinix_metal_device.control_plane.*.access_public_ipv4
   description = "Control Plane Public IPs"
 }
 
 output "Worker_Public_IPs" {
-  value       = metal_device.worker_nodes.*.access_public_ipv4
+  value       = equinix_metal_device.worker_nodes.*.access_public_ipv4
   description = "Worker Node Public IPs"
 }
 
@@ -14,12 +14,12 @@ output "ssh_key_location" {
 }
 
 output "Control_Plane_VIP" {
-  value       = cidrhost(metal_reserved_ip_block.cp_vip.cidr_notation, 0)
+  value       = cidrhost(equinix_metal_reserved_ip_block.cp_vip.cidr_notation, 0)
   description = "The Virtual IP for the Control Plane"
 }
 
 output "Ingress_VIP" {
-  value       = cidrhost(metal_reserved_ip_block.ingress_vip.cidr_notation, 0)
+  value       = cidrhost(equinix_metal_reserved_ip_block.ingress_vip.cidr_notation, 0)
   description = "The Virtual IP for Ingress"
 }
 

--- a/util/test_matrix.sh
+++ b/util/test_matrix.sh
@@ -6,7 +6,7 @@ if [ "$1" = "apply" ]; then
     for os in "${operating_systems[@]}"; do
         mkdir -p $os
         short_name=`echo $os |sed "s/_//g"`
-        nohup terraform apply --auto-approve -state="./$os/terraform.tfstate" -var "operating_system=$os" -var "facility=sv15" -var "plan=c3.small.x86" -var "hostname=$short_name-anothos-baermetal" > ./$os/terraform.log &
+        nohup terraform apply --auto-approve -state="./$os/terraform.tfstate" -var "operating_system=$os" -var "metro=da" -var "plan=c3.small.x86" -var "hostname=$short_name-anothos-baermetal" > ./$os/terraform.log &
     done
 elif [ "$1" = "destroy" ]; then
     for os in "${operating_systems[@]}"; do

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,15 @@
-variable "metal_auth_token" {
+variable "equinix_metal_auth_token" {
   type        = string
   description = "Equinix Metal API Key"
 }
 
-variable "metal_project_id" {
+variable "equinix_metal_project_id" {
   type        = string
   default     = "null"
   description = "Equinix Metal Project ID"
 }
 
-variable "metal_organization_id" {
+variable "equinix_metal_organization_id" {
   type        = string
   default     = "null"
   description = "Equinix Metal Organization ID"
@@ -73,13 +73,13 @@ variable "cluster_name" {
   }
 }
 
-variable "metal_create_project" {
+variable "equinix_metal_create_project" {
   type        = bool
   default     = true
-  description = "Create a Metal Project if this is 'true'. Else use provided 'metal_project_id'"
+  description = "Create a Metal Project if this is 'true'. Else use provided 'equinix_metal_project_id'"
 }
 
-variable "metal_project_name" {
+variable "equinix_metal_project_name" {
   type        = string
   default     = "baremetal-anthos"
   description = "The name of the Metal project if 'create_project' is 'true'."

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
     null = {
       source = "hashicorp/null"
     }
-    metal = {
-      source = "equinix/metal"
+    equinix = {
+      source  = "equinix/equinix"
+      version = "~> 1.14"
     }
     random = {
       source = "hashicorp/random"
@@ -23,5 +24,7 @@ terraform {
       version = "~>3.53.0"
     }
   }
-  required_version = ">= 0.13"
+  provider_meta "equinix" {
+    module_name = "equinix-metal-anthos-on-baremetal"
+  }
 }


### PR DESCRIPTION
What this PR does / why we need it:
It updates the Equinix provider. It allows Vendor to declare the metadata fields. It adds provider meta module_name in Equinix Metal TF configs. 

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Related to https://github.com/equinix/terraform-provider-equinix/issues/252